### PR TITLE
Delete `agent any`

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -6,7 +6,6 @@ pipeline {
     } 
     stages {
         stage('Checkout repo') {
-            agent any 
             steps {
                 sh 'wget -O DOIRootCA2.cer http://sslhelp.doi.net/docs/DOIRootCA2.cer'
                 git "https://github.com/USGS-VIZLAB/stream-stats-art-gallery"


### PR DESCRIPTION
Might be overriding the `agent` specification that we have at the top of the file and causing the current Jenkins build issue.